### PR TITLE
Hotfix: active quam state is also updated when calling node.save

### DIFF
--- a/qualibrate/config/resolvers.py
+++ b/qualibrate/config/resolvers.py
@@ -1,0 +1,28 @@
+import warnings
+from pathlib import Path
+from typing import Optional
+
+from qualibrate_config.models import QualibrateConfig
+
+
+def get_quam_state_path(config: QualibrateConfig) -> Optional[Path]:
+    root = config.__class__._root
+    if root is None:
+        return None
+    raw_config = root._raw_dict
+    state_path = raw_config.get("quam", {}).get("state_path")
+    if state_path is not None:
+        return Path(state_path)
+    am_path = raw_config.get("active_machine", {}).get("path")
+    if am_path is None:
+        return None
+    warnings.warn(
+        (
+            'The config entry "active_machine.path" has been deprecated in '
+            'favor of "quam.state_path". Please update the qualibrate config '
+            "(~/.qualibrate/config.toml) accordingly."
+        ),
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return Path(am_path)

--- a/qualibrate/qualibration_node.py
+++ b/qualibrate/qualibration_node.py
@@ -26,6 +26,7 @@ from qualibrate_config.resolvers import (
     get_qualibrate_config_path,
 )
 
+from qualibrate.config.resolvers import get_quam_state_path
 from qualibrate.models.outcome import Outcome
 from qualibrate.models.run_mode import RunModes
 from qualibrate.models.run_summary.base import BaseRunSummary
@@ -322,8 +323,10 @@ class QualibrationNode(
             logger.warning(msg)
             q_config_path = get_qualibrate_config_path()
             qs = get_qualibrate_config(q_config_path)
+            state_path = get_quam_state_path(qs)
             self.storage_manager = LocalStorageManager(
                 root_data_folder=qs.storage.location,
+                active_machine_path=state_path,
             )
         self.storage_manager.save(
             node=cast("QualibrationNode[NodeParameters]", self)


### PR DESCRIPTION
During the config refactoring, the quam state path was accidentally no longer being passed to the local storage manager. As a result, the quam state was no longer updated when a node was run through the IDE.