### PR TITLE
Add code to copy instance methods from original original class defini…

### DIFF
--- a/qualibrate/q_runnnable.py
+++ b/qualibrate/q_runnnable.py
@@ -108,6 +108,12 @@ class QRunnable(ABC, Generic[CreateParametersType, RunParametersType]):
             __module__=parameters.__class__.__module__,
             **{name: (info.annotation, info) for name, info in fields.items()},
         )
+
+        # Copy methods from the original class
+        for method_name, method in parameters.__class__.__dict__.items():
+            if callable(method) and not method_name.startswith('__'):
+                setattr(model, method_name, method)
+
         if hasattr(parameters, "targets_name"):
             model.targets_name = parameters.targets_name
         return cast(type[CreateParametersType], model)

--- a/qualibrate/q_runnnable.py
+++ b/qualibrate/q_runnnable.py
@@ -111,7 +111,7 @@ class QRunnable(ABC, Generic[CreateParametersType, RunParametersType]):
 
         # Copy methods from the original class
         for method_name, method in parameters.__class__.__dict__.items():
-            if callable(method) and not method_name.startswith('__'):
+            if callable(method) and not method_name.startswith("__"):
                 setattr(model, method_name, method)
 
         if hasattr(parameters, "targets_name"):


### PR DESCRIPTION
Copy all callable attributes from the `parameters` instance to the Pydantic model that eventually replaces the `parameters` instance as `QualibrationNode.parameters`